### PR TITLE
Adding node sorted hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ func main() {
     // Create & generate the tree
     tree := merkle.NewTree()
     // Create & generate the tree with sorted hashes
+    // A tree with pair wise sorted hashes allows for a representation of proofs which are more space efficient
     //tree := merkle.NewTreeWithOpts(TreeOptions{EnableHashSorting: true})
     err = tree.Generate(blocks, md5.New())
     if err != nil {

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ func main() {
 
     // Create & generate the tree
     tree := merkle.NewTree()
+    // Create & generate the tree with sorted hashes
+    //tree := merkle.NewTreeWithOpts(TreeOptions{EnableHashSorting: true})
     err = tree.Generate(blocks, md5.New())
     if err != nil {
         fmt.Println(err)

--- a/merkle.go
+++ b/merkle.go
@@ -192,7 +192,6 @@ func (self *Tree) generateNodeLevel(below []Node, current []Node,
 	for i := 0; i < end; i++ {
 		// Concatenate the two children hashes and hash them, if both are
 		// available, otherwise reuse the hash from the lone left node
-		node := Node{}
 		ileft := 2 * i
 		iright := 2*i + 1
 		left := &below[ileft]

--- a/merkle.go
+++ b/merkle.go
@@ -41,6 +41,8 @@ Example use:
 
         // Create & generate the tree
         tree := merkle.NewTree()
+				// Create & generate the tree with sorted hashes
+    		//tree := merkle.NewTreeWithOpts(TreeOptions{EnableHashSorting: true})
         err = tree.Generate(blocks, md5.New())
         if err != nil {
             fmt.Println(err)

--- a/merkle.go
+++ b/merkle.go
@@ -41,7 +41,8 @@ Example use:
 
         // Create & generate the tree
         tree := merkle.NewTree()
-				// Create & generate the tree with sorted hashes
+				// Create & generate the tree with sorted hashes.
+				// A tree with pair wise sorted hashes allows for a representation of proofs which are more space efficient
     		//tree := merkle.NewTreeWithOpts(TreeOptions{EnableHashSorting: true})
         err = tree.Generate(blocks, md5.New())
         if err != nil {
@@ -216,21 +217,19 @@ func (self *Tree) generateNodeLevel(below []Node, current []Node,
 
 func (self *Tree) generateNode(left, right []byte, h hash.Hash) (Node, error) {
 	data := make([]byte, h.Size()*2)
-	bottomHash := left
-	topHash := right
 	if right == nil {
 		b := data[:h.Size()]
 		copy(b, left)
 		return Node{Hash: b}, nil
 	}
-	if self.Options.EnableHashSorting {
-		if bytes.Compare(left, right) > 0 {
-			bottomHash = right
-			topHash = left
-		}
+	firstHalf := left
+	secondHalf := right
+	if self.Options.EnableHashSorting && bytes.Compare(left, right) > 0 {
+		firstHalf = right
+		secondHalf = left
 	}
-	copy(data[:h.Size()], bottomHash)
-	copy(data[h.Size():], topHash)
+	copy(data[:h.Size()], firstHalf)
+	copy(data[h.Size():], secondHalf)
 
 	return NewNode(h, data)
 }

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -307,16 +307,6 @@ func createDummyTreeData(count, size int, use_rand bool) [][]byte {
 	return data
 }
 
-func randomByteArray(size int) []byte {
-	garbage := make([]byte, size)
-	read := 0
-	for read < size {
-		n, _ := rand.Read(garbage[read:])
-		read += n
-	}
-	return garbage
-}
-
 func verifyGeneratedTree(t *testing.T, tree *Tree, h hash.Hash) {
 	/* Given a generated tree, confirm its state is correct */
 

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -454,18 +454,23 @@ func TestTreeGenerate(t *testing.T) {
 	assert.Equal(t, err.Error(), "Empty tree")
 }
 
-func TestGenerateNode(t *testing.T) {
+func TestGenerateNodeHashOfUnbalance(t *testing.T) {
 	tree := Tree{}
 	tree.Options.EnableHashSorting = true
 	h := NewSimpleHash()
 
-	//Verify last Node's Hash of unbalance should be same as leaf
 	sampleLeft := []byte{203, 225, 206, 227, 57, 204, 31, 188, 40, 131, 158, 32, 174, 43, 15, 187, 176, 223, 90, 55, 162, 35, 25, 177, 219, 173, 93, 54, 138, 119, 188, 56}
 	n, err := tree.generateNode(sampleLeft, nil, h)
 	assert.Nil(t, err)
 	assert.Equal(t, sampleLeft, n.Hash)
+}
 
-	//Verify node hash in lexicographical order
+func TestGenerateNodeHashOrdered(t *testing.T) {
+	tree := Tree{}
+	tree.Options.EnableHashSorting = true
+	h := NewSimpleHash()
+
+	sampleLeft := []byte{203, 225, 206, 227, 57, 204, 31, 188, 40, 131, 158, 32, 174, 43, 15, 187, 176, 223, 90, 55, 162, 35, 25, 177, 219, 173, 93, 54, 138, 119, 188, 56}
 	sampleRight := []byte{193, 201, 112, 48, 157, 84, 238, 81, 120, 81, 228, 112, 38, 213, 168, 50, 37, 170, 137, 211, 44, 177, 75, 68, 152, 252, 54, 145, 145, 146, 154, 136}
 
 	data := make([]byte, h.Size()*2)
@@ -473,19 +478,23 @@ func TestGenerateNode(t *testing.T) {
 	copy(data[h.Size():], sampleLeft)
 
 	expected, _ := NewNode(h, data)
-	n, err = tree.generateNode(sampleLeft, sampleRight, h)
+	n, err := tree.generateNode(sampleLeft, sampleRight, h)
 	assert.Nil(t, err)
 	assert.Equal(t, expected.Hash, n.Hash)
+}
 
-	data = data[:]
+func TestGenerateNodeHashStandard(t *testing.T) {
+	tree := Tree{}
+	h := NewSimpleHash()
+	sampleLeft := []byte{203, 225, 206, 227, 57, 204, 31, 188, 40, 131, 158, 32, 174, 43, 15, 187, 176, 223, 90, 55, 162, 35, 25, 177, 219, 173, 93, 54, 138, 119, 188, 56}
+	sampleRight := []byte{193, 201, 112, 48, 157, 84, 238, 81, 120, 81, 228, 112, 38, 213, 168, 50, 37, 170, 137, 211, 44, 177, 75, 68, 152, 252, 54, 145, 145, 146, 154, 136}
 
-	//Verify node hash in left-right order
-	tree = Tree{}
+	data := make([]byte, h.Size()*2)
 	copy(data[:h.Size()], sampleRight)
 	copy(data[h.Size():], sampleLeft)
 
-	expected, _ = NewNode(h, data)
-	n, err = tree.generateNode(sampleLeft, sampleRight, h)
+	expected, _ := NewNode(h, data)
+	n, err := tree.generateNode(sampleLeft, sampleRight, h)
 	assert.Nil(t, err)
 	assert.Equal(t, expected.Hash, n.Hash)
 }

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -307,6 +307,16 @@ func createDummyTreeData(count, size int, use_rand bool) [][]byte {
 	return data
 }
 
+func randomByteArray(size int) []byte {
+	garbage := make([]byte, size)
+	read := 0
+	for read < size {
+		n, _ := rand.Read(garbage[read:])
+		read += n
+	}
+	return garbage
+}
+
 func verifyGeneratedTree(t *testing.T, tree *Tree, h hash.Hash) {
 	/* Given a generated tree, confirm its state is correct */
 
@@ -460,24 +470,34 @@ func TestGenerateNode(t *testing.T) {
 	h := NewSimpleHash()
 
 	//Verify last Node's Hash of unbalance should be same as leaf
-	sampleLeft := []byte{}
+	sampleLeft := []byte{203, 225, 206, 227, 57, 204, 31, 188, 40, 131, 158, 32, 174, 43, 15, 187, 176, 223, 90, 55, 162, 35, 25, 177, 219, 173, 93, 54, 138, 119, 188, 56}
 	n, err := tree.generateNode(sampleLeft, nil, h)
 	assert.Nil(t, err)
 	assert.Equal(t, sampleLeft, n.Hash)
 
 	//Verify node hash in lexicographical order
-	sampleRight := []byte{}
-	nodeHash := []byte{}
+	sampleRight := []byte{193, 201, 112, 48, 157, 84, 238, 81, 120, 81, 228, 112, 38, 213, 168, 50, 37, 170, 137, 211, 44, 177, 75, 68, 152, 252, 54, 145, 145, 146, 154, 136}
+
+	data := make([]byte, h.Size()*2)
+	copy(data[:h.Size()], sampleRight)
+	copy(data[h.Size():], sampleLeft)
+
+	expected, _ := NewNode(h, data)
 	n, err = tree.generateNode(sampleLeft, sampleRight, h)
 	assert.Nil(t, err)
-	assert.Equal(t, nodeHash, n.Hash)
+	assert.Equal(t, expected.Hash, n.Hash)
+
+	data = data[:]
 
 	//Verify node hash in left-right order
 	tree = Tree{}
-	nodeHash = []byte{}
+	copy(data[:h.Size()], sampleRight)
+	copy(data[h.Size():], sampleLeft)
+
+	expected, _ = NewNode(h, data)
 	n, err = tree.generateNode(sampleLeft, sampleRight, h)
 	assert.Nil(t, err)
-	assert.Equal(t, nodeHash, n.Hash)
+	assert.Equal(t, expected.Hash, n.Hash)
 }
 
 func TestHashOrderedTreeGenerate(t *testing.T) {

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -307,7 +307,7 @@ func createDummyTreeData(count, size int, use_rand bool) [][]byte {
 	return data
 }
 
-func verifyGeneratedTree(t *testing.T, tree *Tree) {
+func verifyGeneratedTree(t *testing.T, tree *Tree, h hash.Hash) {
 	/* Given a generated tree, confirm its state is correct */
 
 	// Nodes should have been created
@@ -343,6 +343,7 @@ func verifyGeneratedTree(t *testing.T, tree *Tree) {
 					"Right child hash should not equal node hash")
 				assert.NotEqual(t, bytes.Equal(n.Left.Hash, n.Hash), true,
 					"Left child hash should not equal node hash")
+				verifyHashInNode(t, tree, n, h)
 			}
 		}
 
@@ -363,10 +364,21 @@ func verifyGeneratedTree(t *testing.T, tree *Tree) {
 	assert.Equal(t, tree.Root(), &rootRow[0],
 		"tree.Root() is not the expected node")
 
+	// Verify Root Hash
+	verifyHashInNode(t, tree, *tree.Root(), h)
+
 	// The Leaves() should the deepest row
 	assert.Equal(t, len(tree.Leaves()),
 		len(tree.GetNodesAtHeight(tree.Height())),
 		"tree.Leaves() is not the expected row")
+}
+
+func verifyHashInNode(t *testing.T, tree *Tree, n Node, h hash.Hash) {
+	/* Given a node it verifies that the Node Hash was calculated correctly */
+	nn, err := tree.generateNode(n.Left.Hash, n.Right.Hash, h)
+
+	assert.Nil(t, err)
+	assert.Equal(t, nn.Hash, n.Hash, "calculated Hash needs to match generated one")
 }
 
 func verifyInitialState(t *testing.T, tree *Tree) {
@@ -402,6 +414,13 @@ func TestNewNode(t *testing.T) {
 func TestNewTree(t *testing.T) {
 	tree := NewTree()
 	verifyInitialState(t, &tree)
+	assert.False(t, tree.Options.EnableHashSorting)
+}
+
+func TestNewTreeWithOpts(t *testing.T) {
+	tree := NewTreeWithOpts(TreeOptions{EnableHashSorting: true})
+	verifyInitialState(t, &tree)
+	assert.True(t, tree.Options.EnableHashSorting)
 }
 
 func TestTreeUngenerated(t *testing.T) {
@@ -418,15 +437,63 @@ func TestTreeUngenerated(t *testing.T) {
 
 func TestTreeGenerate(t *testing.T) {
 	tree := Tree{}
+	h := NewSimpleHash()
 	// Setup some dummy data
 	blockCount := 13
 	blockSize := 16
 	data := createDummyTreeData(blockCount, blockSize, true)
 
 	// Generate the tree
-	err := tree.Generate(data, NewSimpleHash())
+	err := tree.Generate(data, h)
 	assert.Nil(t, err)
-	verifyGeneratedTree(t, &tree)
+	verifyGeneratedTree(t, &tree, h)
+
+	// Generating with no blocks should return error
+	err = tree.Generate(make([][]byte, 0, 1), h)
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "Empty tree")
+}
+
+func TestGenerateNode(t *testing.T) {
+	tree := Tree{}
+	tree.Options.EnableHashSorting = true
+	h := NewSimpleHash()
+
+	//Verify last Node's Hash of unbalance should be same as leaf
+	sampleLeft := []byte{}
+	n, err := tree.generateNode(sampleLeft, nil, h)
+	assert.Nil(t, err)
+	assert.Equal(t, sampleLeft, n.Hash)
+
+	//Verify node hash in lexicographical order
+	sampleRight := []byte{}
+	nodeHash := []byte{}
+	n, err = tree.generateNode(sampleLeft, sampleRight, h)
+	assert.Nil(t, err)
+	assert.Equal(t, nodeHash, n.Hash)
+
+	//Verify node hash in left-right order
+	tree = Tree{}
+	nodeHash = []byte{}
+	n, err = tree.generateNode(sampleLeft, sampleRight, h)
+	assert.Nil(t, err)
+	assert.Equal(t, nodeHash, n.Hash)
+}
+
+func TestHashOrderedTreeGenerate(t *testing.T) {
+	tree := Tree{}
+	tree.Options.EnableHashSorting = true
+	h := NewSimpleHash()
+
+	// Setup some dummy data
+	blockCount := 13
+	blockSize := 16
+	data := createDummyTreeData(blockCount, blockSize, true)
+
+	// Generate the tree
+	err := tree.Generate(data, h)
+	assert.Nil(t, err)
+	verifyGeneratedTree(t, &tree, h)
 
 	// Generating with no blocks should return error
 	err = tree.Generate(make([][]byte, 0, 1), NewSimpleHash())
@@ -452,13 +519,14 @@ func TestGenerateFailedHash(t *testing.T) {
 func TestGetNodesAtHeight(t *testing.T) {
 	// ungenerate tree should return nil
 	tree := NewTree()
+	h := NewSimpleHash()
 	assert.Nil(t, tree.GetNodesAtHeight(1))
 
 	count := 15
 	size := 16
 	data := createDummyTreeData(count, size, true)
 	tree.Generate(data, NewSimpleHash())
-	verifyGeneratedTree(t, &tree)
+	verifyGeneratedTree(t, &tree, h)
 
 	// invalid height should return nil
 	assert.Nil(t, tree.GetNodesAtHeight(0))
@@ -512,15 +580,16 @@ func TestRootHashValue(t *testing.T) {
 	// that finds only the root hash
 
 	tree := Tree{}
+	h := sha256.New()
 	// Setup some dummy data
 	blockCount := 16
 	blockSize := 16
 	data := createDummyTreeData(blockCount, blockSize, true)
 
 	// Generate the tree
-	err := tree.Generate(data, sha256.New())
+	err := tree.Generate(data, h)
 	assert.Nil(t, err)
-	verifyGeneratedTree(t, &tree)
+	verifyGeneratedTree(t, &tree, h)
 
 	// Calculate the root hash with the simpler method
 	merk := simpleMerkle(data)


### PR DESCRIPTION
We love you library, simple and does the job. We would like to be able to hash the children in lexicographical order before calculating the node hash. 
The reason behind it is to simplify our merkle proofs to optimize the data storage/interchange. 

For example:
Instead of passing: 
```
"hashes":[  
        { "right":"kYXAGhDdPiFMq1ZQMOZiKmSf1S1eHNgJ6BIPSIExOj8=" },
        { "left":"GDgT7Km6NK6k4N/Id4CZXErL3p6clNX7sVnlNyegdG0=" },
        { "right":"qOZzS+YM8t1OfC87zEKgkKz6q0f3wwk5+ed+PR/2cDA=" }
    ]
```

We will only pass a list:
```
"hashes": ["kYXAGhDdPiFMq1ZQMOZiKmSf1S1eHNgJ6BIPSIExOj8=", "GDgT7Km6NK6k4N/Id4CZXErL3p6clNX7sVnlNyegdG0=", "qOZzS+YM8t1OfC87zEKgkKz6q0f3wwk5+ed+PR/2cDA="]
```

We of course want to keep the default behavior.

@xsleonard  What do you think?
